### PR TITLE
Initializing CoreData with custom persistent store file URL

### DIFF
--- a/DAO/Classes/CoreDataDAO/Configuration/CoreDataConfiguration.swift
+++ b/DAO/Classes/CoreDataDAO/Configuration/CoreDataConfiguration.swift
@@ -24,6 +24,9 @@ public struct CoreDataConfiguration {
     /// Options for persistence store
     public let options: [String: NSObject]
     
+    /// URL of persistent store file
+    public let persistentStoreURL:URL?
+    
     
     /// Create an instance with specified `containerName`, `storeType`, `options`.
     ///
@@ -31,15 +34,19 @@ public struct CoreDataConfiguration {
     ///   - containerName: name. See above.
     ///   - storeType: store type. See above.
     ///   - options: persistence store options.
+    ///   - persistentStoreURL: URL of persistent store file.
     public init(
         containerName: String,
         storeType: String = NSSQLiteStoreType,
         options: [String : NSObject] =
             [NSMigratePersistentStoresAutomaticallyOption: true as NSObject,
-             NSInferMappingModelAutomaticallyOption: true as NSObject]) {
+             NSInferMappingModelAutomaticallyOption: true as NSObject],
+        persistentStoreURL:URL? = nil) {
+        
         self.containerName = containerName
         self.storeType = storeType
         self.options = options
+        self.persistentStoreURL = persistentStoreURL
     }
     
 }

--- a/DAO/Classes/CoreDataDAO/DAO/CoreDataDAO.swift
+++ b/DAO/Classes/CoreDataDAO/DAO/CoreDataDAO.swift
@@ -60,6 +60,10 @@ open class CoreDataDAO<CDModel: NSManagedObject, Model: Entity> : DAO<Model> {
                             description.setOption($0.value, forKey: $0.key)
                         }
                     description.type = configuration.storeType
+                    
+                    if configuration.persistentStoreURL != nil {
+                        description.url = configuration.persistentStoreURL
+                    }
                 }
             
             var error: Error?
@@ -82,7 +86,7 @@ open class CoreDataDAO<CDModel: NSManagedObject, Model: Entity> : DAO<Model> {
             try persistentStoreCoordinator.addPersistentStore(
                     ofType: configuration.storeType,
                     configurationName: nil,
-                    at: CoreDataDAO.url(storeName: "\(configuration.containerName).db"),
+                    at: configuration.persistentStoreURL ?? CoreDataDAO.url(storeName: "\(configuration.containerName).db"),
                     options: configuration.options)
         }
  

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - DAO (1.3.0):
-    - DAO/CoreData (= 1.3.0)
-    - DAO/Realm (= 1.3.0)
-  - DAO/CoreData (1.3.0)
-  - DAO/Realm (1.3.0):
+  - DAO (1.3.1):
+    - DAO/CoreData (= 1.3.1)
+    - DAO/Realm (= 1.3.1)
+  - DAO/CoreData (1.3.1)
+  - DAO/Realm (1.3.1):
     - RealmSwift
   - Realm (3.1.1):
     - Realm/Headers (= 3.1.1)
@@ -19,7 +19,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  DAO: 2b90d967311eda89a98d4f999c7f4b0e09fbe369
+  DAO: 8d4a7cbd2aaa300ca185ffe628e8110e5d2b8b71
   Realm: 42d1c38a5b1bbcc828b48a7ce702cb86fc68adf4
   RealmSwift: d31937ca6a6ee54acde64ec839523c0a3c04924b
 


### PR DESCRIPTION
Это необходимо если в приложении используется app groups

Например, виджеты могут получить доступ к данным приложения если они работают в одной с ним группе или записывать данные в БД