### PR TITLE
Fixed deletion crash in Realm

### DIFF
--- a/DAO.podspec
+++ b/DAO.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'DAO'
-  s.version          = '1.3.7'
+  s.version          = '1.3.8'
   s.summary          = 'DAO Library'
   s.description      = 'Library provides easy way to cache entities.'
   s.homepage         = 'https://github.com/RedMadRobot/DAO'

--- a/DAO/Classes/RealmDAO/DAO/RealmDAO.swift
+++ b/DAO/Classes/RealmDAO/DAO/RealmDAO.swift
@@ -271,6 +271,8 @@ open class RealmDAO<Model: Entity, RealmModel: RLMEntry>: DAO<Model> {
     
     
     private func cascadeDelete(_ object: AnyObject?) {
+        guard object?.isInvalidated != true else { return }
+        
         if let deletable = object as? CascadeDeletionProtocol {
             deletable.objectsToDelete.forEach { child in
                 cascadeDelete(child)

--- a/DAO/Classes/RealmDAO/DAO/RealmDAO.swift
+++ b/DAO/Classes/RealmDAO/DAO/RealmDAO.swift
@@ -271,7 +271,7 @@ open class RealmDAO<Model: Entity, RealmModel: RLMEntry>: DAO<Model> {
     
     
     private func cascadeDelete(_ object: AnyObject?) {
-        guard object?.isInvalidated != true else { return }
+        guard object?.isInvalidated == false else { return }
         
         if let deletable = object as? CascadeDeletionProtocol {
             deletable.objectsToDelete.forEach { child in


### PR DESCRIPTION
FIxed race condition consequences during object deletion in parallel queues.

How to reproduce:

1. Create any DB Object with `CascadeDeletionProtocol`
2. Save it to Realm
2. Try to delete this object in two queues simultaneously
3. Deletion happens in one queue
4. Deletion tries to happen in second queue
5. It'll crash in CascadeDeletionProtocol implementation because `self` is already invalidated
