### PR TITLE
Исправлена поддержка in-memory Realm для разных потоков внутри одного инстанса DAO

### DIFF
--- a/DAO/Classes/RealmDAO/DAO/RealmDAO.swift
+++ b/DAO/Classes/RealmDAO/DAO/RealmDAO.swift
@@ -286,16 +286,11 @@ open class RealmDAO<Model: Entity, RealmModel: RLMEntry>: DAO<Model> {
     }
     
     private func realm() throws -> Realm {
-        guard configuration.inMemoryIdentifier != nil else {
-            return try Realm(configuration: configuration)
-        }
-        
-        if let realm = inMemoryRealm {
-            return realm
-        }
-        
         let realm = try Realm(configuration: configuration)
-        inMemoryRealm = realm
+
+        if configuration.inMemoryIdentifier != nil {
+            inMemoryRealm = realm
+        }
         
         return realm
     }


### PR DESCRIPTION
При работе с in-memory Realm внутри одного Scope необходимо, чтобы все инстансы были открыты в одном потоке, иначе происходит ошибка доступа к Realm по причине обращения из некорректного потока ('RLMException', reason: 'Realm accessed from incorrect thread.').
Для решения проблемы принято решение изменять ссылку на инстанс in-memory Realm внутри одного инстанса DAO на последний созданный. Таким образом мы не даем возможности существования двум инстансам in-memory Realm с одним идентификатором внутри одного инстанса DAO, а так же сохраняем данные в памяти.